### PR TITLE
Add functionality to write to a temp file through url arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ OPTIONS:
     -g, --gid               Group id to run with
     -s, --signal            Signal to send to the command when exit it (default: 1, SIGHUP)
     -a, --url-arg           Allow client to send command line arguments in URL (eg: http://localhost:7681?arg=foo&arg=bar)
+    -f, --arg-file          File prefix for a unique generated temp file that URL arguments are written to (ex. /tmp/prefix); the generated file's full path is then passed in as a command line argument (ex. /tmp/prefix{unique string})
     -R, --readonly          Do not allow clients to write to the TTY
     -t, --client-option     Send option to client (format: key=value), repeat to add more options
     -T, --terminal-type     Terminal type to report, default: xterm-256color

--- a/man/ttyd.1
+++ b/man/ttyd.1
@@ -64,6 +64,10 @@ Cross platform: macOS, Linux, FreeBSD/OpenBSD, OpenWrt/LEDE, Windows
 \[la]http://localhost:7681?arg=foo&arg=bar\[ra])
 
 .PP
+\-f, \-\-arg\-file
+      Allow client to write URL arguments to a temporary file; the file name is then passed in as a command line argument
+
+.PP
 \-R, \-\-readonly
       Do not allow clients to write to the TTY
 

--- a/man/ttyd.1
+++ b/man/ttyd.1
@@ -65,8 +65,7 @@ Cross platform: macOS, Linux, FreeBSD/OpenBSD, OpenWrt/LEDE, Windows
 
 .PP
 \-f, \-\-arg\-file
-      Allow client to write URL arguments to a temporary file; the file name is then passed in as a command line argument
-
+      File prefix for a unique generated temp file that URL arguments are written to (ex. /tmp/prefix); the generated file's full path is then passed in as a command line argument (ex. /tmp/prefix{unique string})
 .PP
 \-R, \-\-readonly
       Do not allow clients to write to the TTY

--- a/man/ttyd.man.md
+++ b/man/ttyd.man.md
@@ -41,7 +41,7 @@ ttyd 1 "September 2016" ttyd "User Manual"
       Allow client to send command line arguments in URL (eg: http://localhost:7681?arg=foo&arg=bar)
 
   -f, --arg-file
-      Allow client to write URL arguments to a temporary file; the file name is then passed in as a command line argument
+      File prefix for a unique generated temp file that URL arguments are written to (ex. /tmp/prefix); the generated file's full path is then passed in as a command line argument (ex. /tmp/prefix{unique string})
 
   -R, --readonly
       Do not allow clients to write to the TTY

--- a/man/ttyd.man.md
+++ b/man/ttyd.man.md
@@ -40,6 +40,9 @@ ttyd 1 "September 2016" ttyd "User Manual"
   -a, --url-arg
       Allow client to send command line arguments in URL (eg: http://localhost:7681?arg=foo&arg=bar)
 
+  -f, --arg-file
+      Allow client to write URL arguments to a temporary file; the file name is then passed in as a command line argument
+
   -R, --readonly
       Do not allow clients to write to the TTY
 

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -105,9 +105,9 @@ static bool spawn_process(struct pss_tty *pss, uint16_t columns, uint16_t rows) 
       argv[n++] = pss->args[i];
     }
   }
-  else if (server->arg_file) {
+  else if (server->arg_file != NULL) {
     int fd = -1;
-    char filePath[] = "/tmp/XXXXXX";
+    char *filePath = strcat(server->arg_file, "XXXXXX");
 
     if ((fd = mkstemp(filePath)) == -1) {
       lwsl_err("Creation of temp file failed with error: %d (%s)\n", errno, strerror(errno));
@@ -203,7 +203,7 @@ int callback_tty(struct lws *wsi, enum lws_callback_reasons reason, void *user, 
       pss->wsi = wsi;
       pss->lws_close_status = LWS_CLOSE_STATUS_NOSTATUS;
 
-      if (server->url_arg || server->arg_file) {
+      if (server->url_arg || server->arg_file != NULL) {
         while (lws_hdr_copy_fragment(wsi, buf, sizeof(buf), WSI_TOKEN_HTTP_URI_ARGS, n++) > 0) {
           if (strncmp(buf, "arg=", 4) == 0) {
             pss->args = xrealloc(pss->args, (pss->argc + 1) * sizeof(char *));

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -100,9 +100,30 @@ static bool spawn_process(struct pss_tty *pss, uint16_t columns, uint16_t rows) 
   for (i = 0; i < server->argc; i++) {
     argv[n++] = server->argv[i];
   }
-  for (i = 0; i < pss->argc; i++) {
-    argv[n++] = pss->args[i];
+  if (server->url_arg) {
+    for (i = 0; i < pss->argc; i++) {
+      argv[n++] = pss->args[i];
+    }
   }
+  else if (server->arg_file) {
+    int fd = -1;
+    char filePath[] = "/tmp/XXXXXX";
+
+    if ((fd = mkstemp(filePath)) == -1) {
+      lwsl_err("Creation of temp file failed with error: %d (%s)\n", errno, strerror(errno));
+      return false;
+    }
+
+    for (i = 0; i < pss->argc; i++) {
+      if (dprintf(fd, "%s\n", pss->args[i]) < 0) {
+        lwsl_err("Write to temp file failed with error: %d (%s)\n", errno, strerror(errno));
+        return false;
+      }
+    }
+
+    argv[n++] = filePath;
+  }
+
   argv[n] = NULL;
 
   pty_process *process = process_init((void *)pss, server->loop, argv);
@@ -181,7 +202,7 @@ int callback_tty(struct lws *wsi, enum lws_callback_reasons reason, void *user, 
       pss->wsi = wsi;
       pss->lws_close_status = LWS_CLOSE_STATUS_NOSTATUS;
 
-      if (server->url_arg) {
+      if (server->url_arg || server->arg_file) {
         while (lws_hdr_copy_fragment(wsi, buf, sizeof(buf), WSI_TOKEN_HTTP_URI_ARGS, n++) > 0) {
           if (strncmp(buf, "arg=", 4) == 0) {
             pss->args = xrealloc(pss->args, (pss->argc + 1) * sizeof(char *));

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -107,7 +107,8 @@ static bool spawn_process(struct pss_tty *pss, uint16_t columns, uint16_t rows) 
   }
   else if (server->arg_file != NULL) {
     int fd = -1;
-    char *filePath = strcat(server->arg_file, "XXXXXX");
+    char *filePath = xmalloc(strlen(server->arg_file) + 7);
+    sprintf(filePath, "%sXXXXXX", server->arg_file);
 
     if ((fd = mkstemp(filePath)) == -1) {
       lwsl_err("Creation of temp file failed with error: %d (%s)\n", errno, strerror(errno));

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -107,8 +107,10 @@ static bool spawn_process(struct pss_tty *pss, uint16_t columns, uint16_t rows) 
   }
   else if (server->arg_file != NULL) {
     int fd = -1;
-    char *filePath = xmalloc(strlen(server->arg_file) + 7);
-    sprintf(filePath, "%sXXXXXX", server->arg_file);
+    // mkstemp requires the file path to have suffix XXXXXX (len 7)
+    int file_path_len = strlen(server->arg_file) + 7;
+    char *filePath = xmalloc(file_path_len);
+    snprintf(filePath, file_path_len, "%sXXXXXX", server->arg_file);
 
     if ((fd = mkstemp(filePath)) == -1) {
       lwsl_err("Creation of temp file failed with error: %d (%s)\n", errno, strerror(errno));

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -122,6 +122,7 @@ static bool spawn_process(struct pss_tty *pss, uint16_t columns, uint16_t rows) 
     }
 
     argv[n++] = filePath;
+    close(fd);
   }
 
   argv[n] = NULL;

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -104,15 +104,13 @@ static bool spawn_process(struct pss_tty *pss, uint16_t columns, uint16_t rows) 
     for (i = 0; i < pss->argc; i++) {
       argv[n++] = pss->args[i];
     }
-  }
-  else if (server->arg_file != NULL) {
+  } else if (server->arg_file != NULL) {
     int fd = -1;
-    // mkstemp requires the file path to have suffix XXXXXX (len 7)
-    int file_path_len = strlen(server->arg_file) + 7;
+    int file_path_len = strlen(server->arg_file) + 6 /*XXXXXX*/ + 1 /*null character*/;
     char *filePath = xmalloc(file_path_len);
     snprintf(filePath, file_path_len, "%sXXXXXX", server->arg_file);
 
-    if ((fd = mkstemp(filePath)) == -1) {
+    if ((fd = mkstemp(filePath)) != -1) {
       lwsl_err("Creation of temp file failed with error: %d (%s)\n", errno, strerror(errno));
       return false;
     }
@@ -124,8 +122,11 @@ static bool spawn_process(struct pss_tty *pss, uint16_t columns, uint16_t rows) 
       }
     }
 
+    if (close(fd) != 0) {
+      lwsl_err("Close temp file failed with error: %d (%s)\n", errno, strerror(errno));
+      return false
+    }
     argv[n++] = filePath;
-    close(fd);
   }
 
   argv[n] = NULL;

--- a/src/server.c
+++ b/src/server.c
@@ -68,7 +68,7 @@ static const struct option options[] = {{"port", required_argument, NULL, 'p'},
     {"ssl-key", required_argument, NULL, 'K'},
     {"ssl-ca", required_argument, NULL, 'A'},
     {"url-arg", no_argument, NULL, 'a'},
-    {"arg-file", no_argument, NULL, 'f'},
+    {"arg-file", required_argument, NULL, 'f'},
     {"readonly", no_argument, NULL, 'R'},
     {"terminal-type", required_argument, NULL, 'T'},
     {"client-option", required_argument, NULL, 't'},
@@ -82,10 +82,10 @@ static const struct option options[] = {{"port", required_argument, NULL, 'p'},
     {NULL, 0, 0, 0}};
 
 #if LWS_LIBRARY_VERSION_NUMBER < 4000000
-static const char *opt_string = "p:i:c:u:g:s:I:b:6afSC:K:A:Rt:T:Om:oBd:vh";
+static const char *opt_string = "p:i:c:u:g:s:I:b:6af:SC:K:A:Rt:T:Om:oBd:vh";
 #endif
 #if LWS_LIBRARY_VERSION_NUMBER >= 4000000
-static const char *opt_string = "p:i:c:u:g:s:I:b:P:6afSC:K:A:Rt:T:Om:oBd:vh";
+static const char *opt_string = "p:i:c:u:g:s:I:b:P:6af:SC:K:A:Rt:T:Om:oBd:vh";
 #endif
 
 static void print_help() {
@@ -103,7 +103,7 @@ static void print_help() {
           "    -g, --gid               Group id to run with\n"
           "    -s, --signal            Signal to send to the command when exit it (default: 1, SIGHUP)\n"
           "    -a, --url-arg           Allow client to send command line arguments in URL (eg: http://localhost:7681?arg=foo&arg=bar)\n"
-          "    -f, --arg-file          Allow client to write URL arguments to a temporary file; the file name is then passed in as a command line argument\n"
+          "    -f, --arg-file          File prefix for a unique generated temp file that URL arguments are written to (ex. /tmp/prefix); the generated file's full path is then passed in as a command line argument (ex. /tmp/prefix{unique string})\n"
           "    -R, --readonly          Do not allow clients to write to the TTY\n"
           "    -t, --client-option     Send option to client (format: key=value), repeat to add more options\n"
           "    -T, --terminal-type     Terminal type to report, default: xterm-256color\n"
@@ -179,6 +179,7 @@ static struct server *server_new(int argc, char **argv, int start) {
 
 static void server_free(struct server *ts) {
   if (ts == NULL) return;
+  if (ts->arg_file != NULL) free(ts->arg_file);
   if (ts->credential != NULL) free(ts->credential);
   if (ts->index != NULL) free(ts->index);
   free(ts->command);
@@ -328,10 +329,10 @@ int main(int argc, char **argv) {
         break;
       case 'a':
         server->url_arg = true;
-        server->arg_file = false;
+        server->arg_file = NULL;
         break;
       case 'f':
-        server->arg_file = true;
+        server->arg_file = strdup(optarg);
         server->url_arg = false;
         break;
       case 'R':
@@ -535,7 +536,7 @@ int main(int argc, char **argv) {
   }
   if (server->check_origin) lwsl_notice("  check origin: true\n");
   if (server->url_arg) lwsl_notice("  allow url arg to cli arg: true\n");
-  if (server->arg_file) lwsl_notice("  allow url arg to tmp file: true\n");
+  if (server->arg_file != NULL) lwsl_notice("  temp file name prefix: %s\n", server->arg_file);
   if (server->readonly) lwsl_notice("  readonly: true\n");
   if (server->max_clients > 0) lwsl_notice("  max clients: %d\n", server->max_clients);
   if (server->once) lwsl_notice("  once: true\n");

--- a/src/server.c
+++ b/src/server.c
@@ -62,29 +62,30 @@ static const struct option options[] = {{"port", required_argument, NULL, 'p'},
 #if LWS_LIBRARY_VERSION_NUMBER >= 4000000
                                         {"ping-interval", required_argument, NULL, 'P'},
 #endif
-                                        {"ipv6", no_argument, NULL, '6'},
-                                        {"ssl", no_argument, NULL, 'S'},
-                                        {"ssl-cert", required_argument, NULL, 'C'},
-                                        {"ssl-key", required_argument, NULL, 'K'},
-                                        {"ssl-ca", required_argument, NULL, 'A'},
-                                        {"url-arg", no_argument, NULL, 'a'},
-                                        {"readonly", no_argument, NULL, 'R'},
-                                        {"terminal-type", required_argument, NULL, 'T'},
-                                        {"client-option", required_argument, NULL, 't'},
-                                        {"check-origin", no_argument, NULL, 'O'},
-                                        {"max-clients", required_argument, NULL, 'm'},
-                                        {"once", no_argument, NULL, 'o'},
-                                        {"browser", no_argument, NULL, 'B'},
-                                        {"debug", required_argument, NULL, 'd'},
-                                        {"version", no_argument, NULL, 'v'},
-                                        {"help", no_argument, NULL, 'h'},
-                                        {NULL, 0, 0, 0}};
+    {"ipv6", no_argument, NULL, '6'},
+    {"ssl", no_argument, NULL, 'S'},
+    {"ssl-cert", required_argument, NULL, 'C'},
+    {"ssl-key", required_argument, NULL, 'K'},
+    {"ssl-ca", required_argument, NULL, 'A'},
+    {"url-arg", no_argument, NULL, 'a'},
+    {"arg-file", no_argument, NULL, 'f'},
+    {"readonly", no_argument, NULL, 'R'},
+    {"terminal-type", required_argument, NULL, 'T'},
+    {"client-option", required_argument, NULL, 't'},
+    {"check-origin", no_argument, NULL, 'O'},
+    {"max-clients", required_argument, NULL, 'm'},
+    {"once", no_argument, NULL, 'o'},
+    {"browser", no_argument, NULL, 'B'},
+    {"debug", required_argument, NULL, 'd'},
+    {"version", no_argument, NULL, 'v'},
+    {"help", no_argument, NULL, 'h'},
+    {NULL, 0, 0, 0}};
 
 #if LWS_LIBRARY_VERSION_NUMBER < 4000000
-static const char *opt_string = "p:i:c:u:g:s:I:b:6aSC:K:A:Rt:T:Om:oBd:vh";
+static const char *opt_string = "p:i:c:u:g:s:I:b:6afSC:K:A:Rt:T:Om:oBd:vh";
 #endif
 #if LWS_LIBRARY_VERSION_NUMBER >= 4000000
-static const char *opt_string = "p:i:c:u:g:s:I:b:P:6aSC:K:A:Rt:T:Om:oBd:vh";
+static const char *opt_string = "p:i:c:u:g:s:I:b:P:6afSC:K:A:Rt:T:Om:oBd:vh";
 #endif
 
 static void print_help() {
@@ -102,6 +103,7 @@ static void print_help() {
           "    -g, --gid               Group id to run with\n"
           "    -s, --signal            Signal to send to the command when exit it (default: 1, SIGHUP)\n"
           "    -a, --url-arg           Allow client to send command line arguments in URL (eg: http://localhost:7681?arg=foo&arg=bar)\n"
+          "    -f, --arg-file          Allow client to write URL arguments to a temporary file; the file name is then passed in as a command line argument\n"
           "    -R, --readonly          Do not allow clients to write to the TTY\n"
           "    -t, --client-option     Send option to client (format: key=value), repeat to add more options\n"
           "    -T, --terminal-type     Terminal type to report, default: xterm-256color\n"
@@ -326,6 +328,11 @@ int main(int argc, char **argv) {
         break;
       case 'a':
         server->url_arg = true;
+        server->arg_file = false;
+        break;
+      case 'f':
+        server->arg_file = true;
+        server->url_arg = false;
         break;
       case 'R':
         server->readonly = true;
@@ -527,7 +534,8 @@ int main(int argc, char **argv) {
     lwsl_notice("  websocket: %s\n", endpoints.ws);
   }
   if (server->check_origin) lwsl_notice("  check origin: true\n");
-  if (server->url_arg) lwsl_notice("  allow url arg: true\n");
+  if (server->url_arg) lwsl_notice("  allow url arg to cli arg: true\n");
+  if (server->arg_file) lwsl_notice("  allow url arg to tmp file: true\n");
   if (server->readonly) lwsl_notice("  readonly: true\n");
   if (server->max_clients > 0) lwsl_notice("  max clients: %d\n", server->max_clients);
   if (server->once) lwsl_notice("  once: true\n");

--- a/src/server.h
+++ b/src/server.h
@@ -65,6 +65,7 @@ struct server {
   int sig_code;            // close signal
   char sig_name[20];       // human readable signal string
   bool url_arg;            // allow client to send cli arguments in URL
+  bool arg_file;           // allow client to write to a temp file through URL arguments
   bool readonly;           // whether not allow clients to write to the TTY
   bool check_origin;       // whether allow websocket connection from different origin
   int max_clients;         // maximum clients to support

--- a/src/server.h
+++ b/src/server.h
@@ -65,7 +65,7 @@ struct server {
   int sig_code;            // close signal
   char sig_name[20];       // human readable signal string
   bool url_arg;            // allow client to send cli arguments in URL
-  bool arg_file;           // allow client to write to a temp file through URL arguments
+  char *arg_file;          // file prefix for a generated temp file that URL arguments are written to
   bool readonly;           // whether not allow clients to write to the TTY
   bool check_origin;       // whether allow websocket connection from different origin
   int max_clients;         // maximum clients to support


### PR DESCRIPTION
This feature is similar to the existing option that allows url arguments to be passed in as command line arguments. Instead, we create a temporary file in /tmp/ and write the url arguments to this file, separated by newlines. The temporary file name is then passed to the command as a command line argument.
Because of this behaviour, the command line args option and the temporary file option should be mutually exclusive.

We can then use this to pass secret values to the running process as command line arguments are easily visible through process status.

public PR: https://github.com/tsl0922/ttyd/pull/747